### PR TITLE
update github action to point to location of index.html

### DIFF
--- a/.github/workflows/azure-static-web-apps-lively-plant-0d0125a1e.yml
+++ b/.github/workflows/azure-static-web-apps-lively-plant-0d0125a1e.yml
@@ -49,7 +49,7 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_LIVELY_PLANT_0D0125A1E }}
           action: "upload"
           app_location: "flashcard-ui"
-          output_location: "dist/browser"
+          output_location: "dist/flashcard-ui/browser"
           api_location: ""
           github_id_token: ${{ steps.idtoken.outputs.result }}
                 ###### End of Repository/Build Configurations ######


### PR DESCRIPTION
after many moons of debugging the github action we have found the issue: index.html was nested in a location the build file wasn't searching, pointed the build to the correct location and now the build has passed